### PR TITLE
fitsio: use io.ReadFull to correctly load all data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: go
 
 go:
-  - 1.5.1
-  - 1.6.2
-  - tip
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - master
+
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
 
 sudo: false
-
-script:
-    - go get -v ./...
-    - go test -v ./...
 
 notifications:
   email:

--- a/decode.go
+++ b/decode.go
@@ -193,7 +193,7 @@ func (dec *streamDecoder) loadImage(hdr *Header) ([]byte, error) {
 		return buf, nil
 	}
 
-	n, err := dec.r.Read(buf)
+	n, err := io.ReadFull(dec.r, buf)
 	if err != nil {
 		return nil, fmt.Errorf("fitsio: error reading buffer: %v", err)
 	}
@@ -246,7 +246,7 @@ func (dec *streamDecoder) loadTable(hdr *Header, htype HDUType) (*Table, error) 
 	blocksz := alignBlock(datasz + heapsz)
 
 	block := make([]byte, blocksz)
-	n, err := dec.r.Read(block)
+	n, err := io.ReadFull(dec.r, block)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This CL uses io.ReadFull to correctly handle short reads stemming from
large buffer requests (ie: syscall.EAGAIN)

Fixes astrogo/fitsio#22.