### PR TITLE
fitsio: improve perfs of Image.Read

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -1,0 +1,81 @@
+// Copyright 2017 The astrogo Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fitsio
+
+import (
+	"encoding/binary"
+	"io"
+	"math"
+)
+
+func readByte(r io.Reader, v *byte) error {
+	var buf [1]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = buf[0]
+	return nil
+}
+
+func readI8(r io.Reader, v *int8) error {
+	var buf [1]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = int8(buf[0])
+	return nil
+}
+
+func readI16(r io.Reader, v *int16) error {
+	var buf [2]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = int16(binary.BigEndian.Uint16(buf[:]))
+	return nil
+}
+
+func readI32(r io.Reader, v *int32) error {
+	var buf [4]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = int32(binary.BigEndian.Uint32(buf[:]))
+	return nil
+}
+
+func readI64(r io.Reader, v *int64) error {
+	var buf [8]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = int64(binary.BigEndian.Uint64(buf[:]))
+	return nil
+}
+
+func readF32(r io.Reader, v *float32) error {
+	var buf [4]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = math.Float32frombits(binary.BigEndian.Uint32(buf[:]))
+	return nil
+}
+
+func readF64(r io.Reader, v *float64) error {
+	var buf [8]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		return err
+	}
+	*v = math.Float64frombits(binary.BigEndian.Uint64(buf[:]))
+	return nil
+}

--- a/image.go
+++ b/image.go
@@ -119,27 +119,31 @@ func (img *imageHDU) Read(ptr interface{}) error {
 		rv.SetLen(nelmts)
 	}
 
-	var cnv = func(v reflect.Value) reflect.Value {
-		return v
-	}
-
-	bdec := binary.NewDecoder(bytes.NewBuffer(img.raw))
-	bdec.Order = binary.BigEndian
-
+	r := bytes.NewReader(img.raw)
 	switch hdr.Bitpix() {
 	case 8:
 		itype := reflect.TypeOf((*byte)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]byte)
+			for i := 0; i < nelmts; i++ {
+				err = readByte(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []byte to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
+
 		for i := 0; i < nelmts; i++ {
 			var v byte
-			err = bdec.Decode(&v)
+			err = readByte(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}
@@ -148,17 +152,26 @@ func (img *imageHDU) Read(ptr interface{}) error {
 
 	case 16:
 		itype := reflect.TypeOf((*int16)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]int16)
+			for i := 0; i < nelmts; i++ {
+				err = readI16(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []int16 to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
 		for i := 0; i < nelmts; i++ {
 			var v int16
-			err = bdec.Decode(&v)
+			err = readI16(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}
@@ -167,17 +180,26 @@ func (img *imageHDU) Read(ptr interface{}) error {
 
 	case 32:
 		itype := reflect.TypeOf((*int32)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]int32)
+			for i := 0; i < nelmts; i++ {
+				err = readI32(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []int32 to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
 		for i := 0; i < nelmts; i++ {
 			var v int32
-			err = bdec.Decode(&v)
+			err = readI32(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}
@@ -186,17 +208,26 @@ func (img *imageHDU) Read(ptr interface{}) error {
 
 	case 64:
 		itype := reflect.TypeOf((*int64)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]int64)
+			for i := 0; i < nelmts; i++ {
+				err = readI64(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []int64 to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
 		for i := 0; i < nelmts; i++ {
 			var v int64
-			err = bdec.Decode(&v)
+			err = readI64(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}
@@ -205,17 +236,26 @@ func (img *imageHDU) Read(ptr interface{}) error {
 
 	case -32:
 		itype := reflect.TypeOf((*float32)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]float32)
+			for i := 0; i < nelmts; i++ {
+				err = readF32(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []float32 to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
 		for i := 0; i < nelmts; i++ {
 			var v float32
-			err = bdec.Decode(&v)
+			err = readF32(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}
@@ -223,18 +263,27 @@ func (img *imageHDU) Read(ptr interface{}) error {
 		}
 
 	case -64:
-		itype := reflect.TypeOf((*byte)(nil)).Elem()
+		itype := reflect.TypeOf((*float64)(nil)).Elem()
+		if itype == otype {
+			slice := rv.Interface().([]float64)
+			for i := 0; i < nelmts; i++ {
+				err = readF64(r, &slice[i])
+				if err != nil {
+					return fmt.Errorf("fitsio: %v", err)
+				}
+			}
+			return nil
+		}
+
 		if !rt.Elem().ConvertibleTo(itype) {
 			return fmt.Errorf("fitsio: can not convert []float64 to %s", rt.Name())
 		}
-		if itype != otype {
-			cnv = func(v reflect.Value) reflect.Value {
-				return v.Convert(otype)
-			}
+		cnv := func(v reflect.Value) reflect.Value {
+			return v.Convert(otype)
 		}
 		for i := 0; i < nelmts; i++ {
 			var v float64
-			err = bdec.Decode(&v)
+			err = readF64(r, &v)
 			if err != nil {
 				return fmt.Errorf("fitsio: %v", err)
 			}


### PR DESCRIPTION
This CL provides a fast-path for when the on-disk data and the provided
data are of the same type, for Image.Read.

```
name                   old time/op    new time/op    delta
ImageReadF64_10-4        4.95µs ± 6%    0.91µs ± 1%  -81.69%  (p=0.000 n=10+7)
ImageReadF64_100-4       44.2µs ± 4%     6.0µs ± 8%  -86.41%  (p=0.000 n=8+10)
ImageReadF64_1000-4       431µs ± 7%      58µs ± 5%  -86.58%  (p=0.000 n=10+10)
ImageReadF64_10000-4     4.38ms ± 4%    0.58ms ± 7%  -86.86%  (p=0.000 n=10+10)
ImageReadF64_100000-4    46.5ms ± 5%     6.1ms ± 3%  -86.84%  (p=0.000 n=10+10)

name                   old alloc/op   new alloc/op   delta
ImageReadF64_10-4          480B ± 0%      160B ± 0%  -66.67%  (p=0.000 n=10+10)
ImageReadF64_100-4       3.36kB ± 0%    0.88kB ± 0%  -73.81%  (p=0.000 n=10+10)
ImageReadF64_1000-4      32.2kB ± 0%     8.1kB ± 0%  -74.88%  (p=0.000 n=10+10)
ImageReadF64_10000-4      320kB ± 0%      80kB ± 0%  -74.99%  (p=0.000 n=10+10)
ImageReadF64_100000-4    3.20MB ± 0%    0.80MB ± 0%  -75.00%  (p=0.000 n=7+10)

name                   old allocs/op  new allocs/op  delta
ImageReadF64_10-4          43.0 ± 0%      12.0 ± 0%  -72.09%  (p=0.000 n=10+10)
ImageReadF64_100-4          403 ± 0%       102 ± 0%  -74.69%  (p=0.000 n=10+10)
ImageReadF64_1000-4       4.00k ± 0%     1.00k ± 0%  -74.97%  (p=0.000 n=10+10)
ImageReadF64_10000-4      40.0k ± 0%     10.0k ± 0%  -75.00%  (p=0.000 n=10+10)
ImageReadF64_100000-4      400k ± 0%      100k ± 0%  -75.00%  (p=0.000 n=10+10)
```