### PR TITLE
support writing of image cubes

### DIFF
--- a/header.go
+++ b/header.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strconv"
 )
 
 // Header describes a Header-Data Unit of a FITS file
@@ -57,29 +58,18 @@ func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 	}
 
 	if _, ok := keys["NAXIS"]; !ok {
-		dcards = append(dcards, Card{
+		cards = append(cards, Card{
 			Name:    "NAXIS",
 			Value:   len(hdr.Axes()),
 			Comment: "number of data axes",
 		})
-	}
-
-	if len(hdr.Axes()) >= 1 {
-		if _, ok := keys["NAXIS1"]; !ok {
-			dcards = append(dcards, Card{
-				Name:    "NAXIS1",
-				Value:   hdr.Axes()[0],
-				Comment: "length of data axis 1",
-			})
-		}
-	}
-
-	if len(hdr.Axes()) >= 2 {
-		if _, ok := keys["NAXIS2"]; !ok {
-			dcards = append(dcards, Card{
-				Name:    "NAXIS2",
-				Value:   hdr.Axes()[1],
-				Comment: "length of data axis 2",
+		nax := len(hdr.Axes())
+		for i := 0; i < nax; i++ {
+			axis := strconv.Itoa(i + 1) // index from 0, hdu starts at NAXIS1
+			cards = append(cards, Card{
+				Name:    "NAXIS" + axis,
+				Value:   hdr.Axes()[i],
+				Comment: "length of data axis " + axis,
 			})
 		}
 	}

--- a/header.go
+++ b/header.go
@@ -38,6 +38,10 @@ func newHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 
 // NewHeader creates a new Header from a set of Cards, HDU Type, bitpix and axes.
 func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
+	// short circuit: too many axes violates the FITS standard
+	if len(axes) > 999 {
+		panic(fmt.Sprintf("len(axes) is %d, the FITS standard only allows 999 dims", len(axes)))
+	}
 	hdr := newHeader(cards, htype, bitpix, axes)
 
 	// add (some) mandatory cards (BITPIX, NAXES, AXIS1, AXIS2)

--- a/header.go
+++ b/header.go
@@ -58,7 +58,7 @@ func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 	}
 
 	if _, ok := keys["NAXIS"]; !ok {
-		dcards = append(cards, Card{
+		dcards = append(dcards, Card{
 			Name:    "NAXIS",
 			Value:   len(hdr.Axes()),
 			Comment: "number of data axes",
@@ -66,11 +66,14 @@ func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 		nax := len(hdr.Axes())
 		for i := 0; i < nax; i++ {
 			axis := strconv.Itoa(i + 1) // index from 0, hdu starts at NAXIS1
-			dcards = append(cards, Card{
-				Name:    "NAXIS" + axis,
-				Value:   hdr.Axes()[i],
-				Comment: "length of data axis " + axis,
-			})
+			key := "NAXIS" + axis
+			if _, ok := keys[key]; !ok {
+				dcards = append(dcards, Card{
+					Name:    key,
+					Value:   hdr.Axes()[i],
+					Comment: "length of data axis " + axis,
+				})
+			}
 		}
 	}
 

--- a/header.go
+++ b/header.go
@@ -58,7 +58,7 @@ func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 	}
 
 	if _, ok := keys["NAXIS"]; !ok {
-		cards = append(cards, Card{
+		dcards = append(cards, Card{
 			Name:    "NAXIS",
 			Value:   len(hdr.Axes()),
 			Comment: "number of data axes",
@@ -66,7 +66,7 @@ func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 		nax := len(hdr.Axes())
 		for i := 0; i < nax; i++ {
 			axis := strconv.Itoa(i + 1) // index from 0, hdu starts at NAXIS1
-			cards = append(cards, Card{
+			dcards = append(cards, Card{
 				Name:    "NAXIS" + axis,
 				Value:   hdr.Axes()[i],
 				Comment: "length of data axis " + axis,

--- a/header.go
+++ b/header.go
@@ -40,7 +40,7 @@ func newHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 func NewHeader(cards []Card, htype HDUType, bitpix int, axes []int) *Header {
 	// short circuit: too many axes violates the FITS standard
 	if len(axes) > 999 {
-		panic(fmt.Sprintf("len(axes) is %d, the FITS standard only allows 999 dims", len(axes)))
+		panic(fmt.Errorf("fitsio: too many axes (got=%d > 999)", len(axes)))
 	}
 	hdr := newHeader(cards, htype, bitpix, axes)
 

--- a/image.go
+++ b/image.go
@@ -310,6 +310,13 @@ func (img *imageHDU) Write(data interface{}) error {
 		for _, v := range data {
 			w.writeI16(v)
 		}
+	case []uint16:
+		if hdr.Bitpix() != 16 {
+			return fmt.Errorf("fitsio: got a %T but bitpix!=%d", data, hdr.Bitpix())
+		}
+		for _, v := range data {
+			w.writeU16(v)
+		}
 
 	case []int32:
 		if hdr.Bitpix() != 32 {
@@ -318,6 +325,13 @@ func (img *imageHDU) Write(data interface{}) error {
 		for _, v := range data {
 			w.writeI32(v)
 		}
+	case []uint32:
+		if hdr.Bitpix() != 16 {
+			return fmt.Errorf("fitsio: got a %T but bitpix!=%d", data, hdr.Bitpix())
+		}
+		for _, v := range data {
+			w.writeU32(v)
+		}
 
 	case []int64:
 		if hdr.Bitpix() != 64 {
@@ -325,6 +339,13 @@ func (img *imageHDU) Write(data interface{}) error {
 		}
 		for _, v := range data {
 			w.writeI64(v)
+		}
+	case []uint64:
+		if hdr.Bitpix() != 16 {
+			return fmt.Errorf("fitsio: got a %T but bitpix!=%d", data, hdr.Bitpix())
+		}
+		for _, v := range data {
+			w.writeU64(v)
 		}
 
 	case []float32:

--- a/image_test.go
+++ b/image_test.go
@@ -889,17 +889,17 @@ func benchImageWrite(b *testing.B, bitpix int, n int) {
 		panic(fmt.Errorf("invalid bitpix=%d", bitpix))
 	}
 
-	img := NewImage(bitpix, axes)
-	defer img.Close()
-
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	var img *imageHDU
 	for i := 0; i < b.N; i++ {
+		img = NewImage(bitpix, axes)
 		err = img.Write(ptr)
 		if err != nil {
 			b.Fatal(err)
 		}
+		img.Close()
 	}
 
 	err = f.Write(img)

--- a/image_test.go
+++ b/image_test.go
@@ -423,7 +423,6 @@ func TestImageRW(t *testing.T) {
 func TestImageCubeRoundTrip(t *testing.T) {
 	strides := []int{2, 3, 6} // non repetitive, aperiodic strides
 
-	// the data looks like [0, 1, 2, ...]
 	data := make([]int16, 2*3*6)
 	for i := 0; i < len(data); i++ {
 		data[i] = int16(i - 32768)
@@ -436,7 +435,8 @@ func TestImageCubeRoundTrip(t *testing.T) {
 	im := NewImage(16, strides)
 	cards := []Card{
 		{Name: "BZERO", Value: 32768},
-		{Name: "BSCALE", Value: 1.}}
+		{Name: "BSCALE", Value: 1.},
+	}
 	im.Header().Append(cards...)
 	err = im.Write(data)
 	if err != nil {

--- a/image_test.go
+++ b/image_test.go
@@ -970,3 +970,14 @@ func benchImageWrite(b *testing.B, bitpix int, n int) {
 
 	return
 }
+
+func TestPanicWhenNAXISTooLarge(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected panic on too many axes")
+		}
+	}()
+	ax := make([]int, 1000)
+	_ = NewImage(32, ax)
+}

--- a/phdu.go
+++ b/phdu.go
@@ -83,26 +83,6 @@ func NewPrimaryHDU(hdr *Header) (Image, error) {
 		}
 	}
 
-	if len(hdr.Axes()) >= 1 {
-		if _, ok := keys["NAXIS1"]; !ok {
-			cards = append(cards, Card{
-				Name:    "NAXIS1",
-				Value:   hdr.Axes()[0],
-				Comment: "length of data axis 1",
-			})
-		}
-	}
-
-	if len(hdr.Axes()) >= 2 {
-		if _, ok := keys["NAXIS2"]; !ok {
-			cards = append(cards, Card{
-				Name:    "NAXIS2",
-				Value:   hdr.Axes()[1],
-				Comment: "length of data axis 2",
-			})
-		}
-	}
-
 	phdr := *hdr
 	phdr.cards = append(cards, hdr.cards...)
 	hdu := &primaryHDU{

--- a/phdu.go
+++ b/phdu.go
@@ -4,7 +4,10 @@
 
 package fitsio
 
-import "reflect"
+import (
+	"reflect"
+	"strconv"
+)
 
 type primaryHDU struct {
 	imageHDU
@@ -69,6 +72,15 @@ func NewPrimaryHDU(hdr *Header) (Image, error) {
 			Value:   len(hdr.Axes()),
 			Comment: "number of data axes",
 		})
+		nax := len(hdr.Axes())
+		for i := 0; i < nax; i++ {
+			axis := strconv.Itoa(i + 1) // index from 0, hdu starts at NAXIS1
+			cards = append(cards, Card{
+				Name:    "NAXIS" + axis,
+				Value:   hdr.Axes()[i],
+				Comment: "length of data axis " + axis,
+			})
+		}
 	}
 
 	if len(hdr.Axes()) >= 1 {

--- a/phdu.go
+++ b/phdu.go
@@ -4,10 +4,7 @@
 
 package fitsio
 
-import (
-	"reflect"
-	"strconv"
-)
+import "reflect"
 
 type primaryHDU struct {
 	imageHDU
@@ -72,15 +69,6 @@ func NewPrimaryHDU(hdr *Header) (Image, error) {
 			Value:   len(hdr.Axes()),
 			Comment: "number of data axes",
 		})
-		nax := len(hdr.Axes())
-		for i := 0; i < nax; i++ {
-			axis := strconv.Itoa(i + 1) // index from 0, hdu starts at NAXIS1
-			cards = append(cards, Card{
-				Name:    "NAXIS" + axis,
-				Value:   hdr.Axes()[i],
-				Comment: "length of data axis " + axis,
-			})
-		}
 	}
 
 	phdr := *hdr


### PR DESCRIPTION
this fix begins to allow fitsio to properly write image cubes, but does not fully complete that work (I think).  I don't know whether NAXIS > 3 would violate the standard, but this expansion allows it to be arbitrary without special casing 1 and 2 dims.

My application is streaming images from a wavefront sensor that runs at 500Hz to disk for archive parallel to the control loop.  I double buffer the images and roll them up into bundles of up to 10k, which produces files that look like `0-9999.fits`, `10000-19999.fits`, and so forth.  These will be ~800MB a piece.  I expect each to be a cube of `10000xNxM`.  This chunking allows some level of "streaming" and avoids cfitsio's 2GB limit for readers in matlab and python.

it would be pretty optimal if `*fitsio.imageHDU` allowed multiple calls to write, but the buffer size internal to fitsio is set on write, so there will be something like data corruption from multiple calls to write.  I would expect that this PR would include additional commits that make those changes.  I am not yet familiar enough with fitsio's guts to finish making them.